### PR TITLE
Pin Next.js to 15.4.1

### DIFF
--- a/starters/nextjs-starter-approuter-ts/package.json
+++ b/starters/nextjs-starter-approuter-ts/package.json
@@ -34,7 +34,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "dotenv": "^16.4.5",
-    "next": "^15.4.1",
+    "next": "15.4.1",
     "query-string": "^8.2.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",


### PR DESCRIPTION
Something broke between Next.js 15.4.1 and 15.4.4.

Today I did a fresh install via `pcc init SITE_NAME --eslint --ts  --appRouter` and I got `15.4.4`. That yield errors in `npm run build` like

```
Type error: Type 'typeof import("/workspace/app/api/pantheoncloud/[...command]/route")' does not satisfy the constraint 'RouteHandlerConfig<"/api/pantheoncloud/[...command]">'.
Types of property 'GET' are incompatible.
Type 'Handler' is not assignable to type '(request: NextRequest, context: { params: Promise<{ command: string[]; }>; }) => void | Response | Promise<void | Response>'.
Types of parameters 'req' and 'request' are incompatible.
Type 'NextRequest' is missing the following properties from type 'NextApiRequest': query, env, aborted, httpVersion, and 67 more.
```

After lots of trying to fix application code I decided to try downgrading Next. going back to 15.4.1 worked.

For Next steps it is worth trying 15.4.2 and 15.4.3 to narrow things down and then checking against the Next.js issue queue.